### PR TITLE
feat: DM数据库适配

### DIFF
--- a/databases/mysqldb/db.go
+++ b/databases/mysqldb/db.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"gitee.com/chunanyong/dm"
-	"github.com/chuck1024/gd"
 	log "github.com/chuck1024/gd/dlog"
 	"github.com/chuck1024/gd/runtime/pc"
 	"gopkg.in/ini.v1"
@@ -317,26 +316,22 @@ func (c *MysqlClient) IsExistTable(tableName string) (bool, error) {
 	if c.DbType == "dm" {
 		ret, err := c.Query((*TableName)(nil), fmt.Sprintf("select SEGMENT_NAME AS TABLE_NAME  from dba_segments where dba_segments.OWNER='%s' and SEGMENT_NAME='%s';", db, tableName))
 		if err != nil {
-			gd.Error("IsExistTable dm query occur error:%v", err)
-			return false, err
+			return false, errors.New(fmt.Sprintf("IsExistTable dm query occur error:%v", err))
 		}
 
 		if ret == nil {
-			gd.Info("IsExistTable dm Query is nil")
-			return false, nil
+			return false, errors.New(fmt.Sprintf("IsExistTable dm Query is nil"))
 		}
 
 		return ret.(*TableName).TableName == tableName, nil
 	} else {
 		ret, err := c.Query((*TableName)(nil), fmt.Sprintf("select TABLE_NAME from INFORMATION_SCHEMA.TABLES where TABLE_SCHEMA = '%s' and  TABLE_NAME ='%s';", db, tableName))
 		if err != nil {
-			gd.Error("IsExistTable mysql query occur error:%v", err)
-			return false, err
+			return false, errors.New(fmt.Sprintf("IsExistTable mysql query occur error:%v", err))
 		}
 
 		if ret == nil {
-			gd.Info("IsExistTable mysql Query is nil")
-			return false, nil
+			return false, errors.New(fmt.Sprintf("IsExistTable mysql Query is nil"))
 		}
 		return ret.(*TableName).TableName == tableName, nil
 	}

--- a/databases/mysqldb/db.go
+++ b/databases/mysqldb/db.go
@@ -20,7 +20,6 @@ import (
 	"sync"
 	"time"
 
-	_ "gitee.com/chunanyong/dm"
 	"github.com/go-sql-driver/mysql"
 )
 

--- a/databases/mysqldb/dbwrap.go
+++ b/databases/mysqldb/dbwrap.go
@@ -9,15 +9,18 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"gitee.com/chunanyong/dm"
 	log "github.com/chuck1024/gd/dlog"
 	"github.com/chuck1024/gd/runtime/gl"
 	"github.com/chuck1024/gd/runtime/pc"
 	"reflect"
+	"strconv"
 	"strings"
 	"time"
 
 	"runtime"
 
+	_ "gitee.com/chunanyong/dm"
 	_ "github.com/go-sql-driver/mysql"
 )
 
@@ -173,7 +176,7 @@ func (db *DbWrap) Query(query string, args ...interface{}) (rs *sql.Rows, err er
 		turn++
 		rs, err = db.doQuery(query, args...)
 		if err != nil {
-			//only retry on connection error
+			// only retry on connection error
 			if IsTimeoutError(err) || IsDbConnError(err) {
 				continue
 			} else {
@@ -217,6 +220,9 @@ func (db *DbWrap) doQuery(query string, args ...interface{}) (rs *sql.Rows, err 
 
 	gl.Incr(db.glDbReadCount(), 1)
 	ctx, cancel := context.WithTimeout(context.Background(), db.Timeout)
+	if db.mysqlClient.DbType == "dm" {
+		ctx = context.Background()
+	}
 	rs, err = db.DB.QueryContext(ctx, query, args...)
 	if err != nil {
 		if cancel != nil {
@@ -258,6 +264,9 @@ func (db *DbWrap) ExecContext(ctx context.Context, query string, args ...interfa
 	if ctx == nil {
 		ct, cancel := context.WithTimeout(context.Background(), db.Timeout)
 		ctx = ct
+		if db.mysqlClient.DbType == "dm" {
+			ctx = context.Background()
+		}
 		defer cancel()
 	}
 	r, err = targetDb.DB.ExecContext(ctx, query, args...)
@@ -286,6 +295,9 @@ func (db *DbWrap) ExecTransaction(transactionExec TransactionExec) (r sql.Result
 
 	gl.Incr(db.glDbTransactionCount(), 1)
 	ctx, cancel := context.WithTimeout(context.Background(), db.Timeout)
+	if db.mysqlClient.DbType == "dm" {
+		ctx = context.Background()
+	}
 	defer cancel()
 
 	var tx *sql.Tx
@@ -325,14 +337,28 @@ type Row struct {
 // If more than one row matches the query,
 // Scan uses the first row and discards the rest. If no row matches
 // the query, Scan returns ErrNoRows.
-func (r *Row) Scan(dest ...interface{}) error {
+func (r *Row) Scan(indexMap map[int]int, dest ...interface{}) error {
 	if r.err != nil {
 		return r.err
 	}
 	defer r.rows.Close()
+
 	for _, dp := range dest {
 		if _, ok := dp.(*sql.RawBytes); ok {
 			return errors.New("sql: RawBytes isn't allowed on Row.Scan")
+		}
+	}
+
+	var tempScan []interface{}
+	for i, dp := range dest {
+		if indexMap == nil {
+			tempScan = append(tempScan, dp)
+		} else {
+			if _, ok := indexMap[i]; ok {
+				tempScan = append(tempScan, &dm.DmClob{})
+			} else {
+				tempScan = append(tempScan, dp)
+			}
 		}
 	}
 
@@ -342,9 +368,40 @@ func (r *Row) Scan(dest ...interface{}) error {
 		}
 		return sql.ErrNoRows
 	}
-	err := r.rows.Scan(dest...)
+
+	err := r.rows.Scan(tempScan...)
 	if err != nil {
 		return err
+	}
+
+	// add value from tempDest to dest  td->ptr
+	for i, td := range tempScan {
+		if dmClob, isok := td.(*dm.DmClob); isok {
+			// Get the length
+			dmlen, errLength := dmClob.GetLength()
+			if errLength != nil {
+				return errLength
+			}
+
+			// Convert int64 to int type
+			strInt64 := strconv.FormatInt(dmlen, 10)
+			dmlenInt, errAtoi := strconv.Atoi(strInt64)
+			if errAtoi != nil {
+				return errAtoi
+			}
+
+			// Read string
+			str, errReadString := dmClob.ReadString(1, dmlenInt)
+			if errReadString != nil {
+				return errReadString
+			}
+			dv := reflect.Indirect(reflect.ValueOf(dest[i]))
+			if dv.Kind() != reflect.Struct {
+				dv.SetString(str)
+			} else {
+				dv.FieldByName("String").SetString(str)
+			}
+		}
 	}
 	// Make sure the query can be processed to completion with no errors.
 	if err := r.rows.Close(); err != nil {

--- a/databases/mysqldb/sample/conf/conf.ini
+++ b/databases/mysqldb/sample/conf/conf.ini
@@ -1,8 +1,9 @@
-[Mysql.test]
+[Mysql.honeypot]
 master_ip = 127.0.0.1
 master_port = 3306
 user = root
-password = password
+password = 123456
 timeout = 5s
 max_open = 100
 max_idle = 8
+# db_type = dm/mysql default->mysql

--- a/databases/mysqldb/sample/sample.go
+++ b/databases/mysqldb/sample/sample.go
@@ -11,26 +11,47 @@ import (
 )
 
 type TestDB struct {
-	Id       uint64  `json:"id" mysqlField:"id"`
-	Name     string  `json:"name" mysqlField:"name"`
-	CardId   uint64  `json:"card_id" mysqlField:"card_id"`
-	Sex      string  `json:"sex" mysqlField:"sex"`
-	Birthday uint64  `json:"birthday" mysqlField:"birthday"`
-	Status   uint8   `json:"status" mysqlField:"status"`
-	CreateTs uint64  `json:"create_time" mysqlField:"create_time"`
-	UpdateTs []uint8 `json:"update_time" mysqlField:"update_time"`
+	Id       uint64 `json:"id" mysqlField:"id"`
+	Name     string `json:"name" mysqlField:"name"`
+	CardId   uint64 `json:"card_id" mysqlField:"card_id"`
+	Sex      string `json:"sex" mysqlField:"sex"`
+	Birthday uint64 `json:"birthday" mysqlField:"birthday"`
+	Status   uint64 `json:"status" mysqlField:"status"`
+	CreateTs uint64 `json:"create_time" mysqlField:"create_time"`
+	UpdateTs uint64 `json:"update_time" mysqlField:"update_time"`
+}
+
+type TestDB1 struct {
+	Id         uint64 `json:"id" mysqlField:"id"`
+	Name       string `json:"name" mysqlField:"name"`
+	CreateTime int    `json:"createTime" mysqlField:"createTime"`
 }
 
 func main() {
 	defer gd.LogClose()
-	o := mysqldb.MysqlClient{DataBase: "test"}
+	gd.SetConfPath("H:\\GoProgram\\Go\\src\\gd\\databases\\mysqldb\\sample\\conf\\conf.ini")
+	o := mysqldb.MysqlClient{DataBase: "honeypot", DbConf: gd.GetConfFile()}
 	if err := o.Start(); err != nil {
 		gd.Error("err:%s", err)
 		return
 	}
 
 	// Query
-	query := "select ? from test where id = ?"
+	query := "select ? from test1 where id =?"
+	var err error
+
+	// Add
+	insert := &TestDB{
+		Name:     "chucks",
+		CardId:   132124,
+		Sex:      "male",
+		Birthday: 1312412,
+		Status:   1,
+		CreateTs: 112131231,
+		UpdateTs: 112131231,
+	}
+
+	// 支持
 	data, err := o.Query((*TestDB)(nil), query, 2)
 	if err != nil {
 		gd.Error("err:%s", err)
@@ -42,34 +63,61 @@ func main() {
 	}
 	gd.Debug("%v", data.(*TestDB))
 
-	// Add
-	insert := &TestDB{
-		Name:     "chucks",
-		CardId:   1026,
-		Sex:      "male",
-		Birthday: 19991010,
-		Status:   1,
-	}
-
-	err = o.Add("test", insert, true)
+	// dm 不支持
+	err = o.Add("test", insert, false)
 	if err != nil {
 		gd.Error("%s", err)
 	}
 
-	// queryList
-	query = "select ? from test where name = ? "
-	retList, err := o.QueryList((*TestDB)(nil), query, "chucks")
-	testList := make([]*TestDB, 0)
+	updateData := &TestDB1{
+		Id:         2,
+		Name:       "asdasda",
+		CreateTime: 13152512,
+	}
+	primaryKey := []string{"id"}
+	updateFiled := []string{"name", "createTime"}
+
+	// false 支持
+	_, err = o.InsertOrUpdateOnDup("test1", updateData, primaryKey, updateFiled, false)
+	if err != nil {
+		gd.Error("%s", err)
+	}
+
+	// 支持
+	c, err := o.GetCount("select count(*) from test")
+	if err != nil {
+		gd.Error("%s", err)
+	}
+	gd.Info("count %d", c)
+
+	// 支持
+	_, err = o.AddEscapeAutoIncrAndRetLastId("test", insert, "id")
+	if err != nil {
+		gd.Error("%s", err)
+	}
+
+	// 支持
+	query = "select ? from test1 where name = ? "
+	retList, err := o.QueryList((*TestDB1)(nil), query, "xianglei")
+	testList := make([]*TestDB1, 0)
 	for _, ret := range retList {
-		product, _ := ret.(*TestDB)
+		product, _ := ret.(*TestDB1)
 		testList = append(testList, product)
 	}
-	gd.Debug("%v", testList[0].CardId)
+	gd.Debug("%v", testList[0].Name)
 
-	// update
+	// 支持
 	where := make(map[string]interface{}, 0)
 	where["id"] = 2
-	err = o.Update("test", &TestDB{Sex: "female"}, where, []string{"sex"})
+	err = o.Update("test1", &TestDB1{Name: "xxx"}, where, []string{"name"})
+	if err != nil {
+		gd.Error("%s", err)
+	}
+
+	// 支持
+	con := make(map[string]interface{})
+	con["name"] = "xxx"
+	_, err = o.Delete("test", con)
 	if err != nil {
 		gd.Error("%s", err)
 	}

--- a/databases/mysqldb/sample/sample.sql
+++ b/databases/mysqldb/sample/sample.sql
@@ -11,3 +11,32 @@ CREATE TABLE `test` (
   UNIQUE KEY `uk_card_id` (`card_id`) USING BTREE,
   KEY `abc` (`name`,`card_id`,`birthday`)
 ) ENGINE=InnoDB AUTO_INCREMENT=0 DEFAULT CHARSET=utf8 COMMENT='测试';
+
+CREATE TABLE "honeypot"."test"
+(
+    "id" BIGINT IDENTITY(3, 1) NOT NULL,
+    "name" VARCHAR(128) DEFAULT '' NOT NULL,
+    "card_id" DECIMAL DEFAULT 0 NOT NULL,
+    "sex" VARCHAR(10) DEFAULT '' NOT NULL,
+    "birthday" DECIMAL DEFAULT 0 NOT NULL,
+    "status" INT DEFAULT 0 NOT NULL,
+    "create_time" DECIMAL DEFAULT 0 NOT NULL,
+    "update_time" TIMESTAMP(0) DEFAULT CURRENT_TIMESTAMP() NOT NULL,
+    NOT CLUSTER PRIMARY KEY("id"),
+    CONSTRAINT "uk_card_id" UNIQUE("card_id"),
+    CHECK("card_id" >= 0)
+    ,CHECK("birthday" >= 0)
+    ,CHECK("status" >= 0)
+    ,CHECK("create_time" >= 0)) STORAGE(ON "MAIN", CLUSTERBTR) ;
+
+COMMENT ON TABLE "honeypot"."test" IS '测试';
+COMMENT ON COLUMN "honeypot"."test"."birthday" IS '出生年月日';
+COMMENT ON COLUMN "honeypot"."test"."card_id" IS '身份证';
+COMMENT ON COLUMN "honeypot"."test"."create_time" IS '创建时间';
+COMMENT ON COLUMN "honeypot"."test"."name" IS '姓名';
+COMMENT ON COLUMN "honeypot"."test"."sex" IS '性别';
+COMMENT ON COLUMN "honeypot"."test"."status" IS '状态';
+COMMENT ON COLUMN "honeypot"."test"."update_time" IS '更新时间';
+
+
+CREATE  INDEX "abc" ON "honeypot"."test"("name" ASC,"card_id" ASC,"birthday" ASC) STORAGE(ON "MAIN", CLUSTERBTR) ;

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/chuck1024/gd
 go 1.15
 
 require (
+	gitee.com/chunanyong/dm v1.8.5
 	github.com/bitly/go-simplejson v0.5.0
 	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 // indirect
 	github.com/facebookgo/structtag v0.0.0-20150214074306-217e25fb9691


### PR DESCRIPTION
1. 适配达梦数据库，除事务外其他方法均已适配
2. 新增db_type类型字段做数据库切换判断
3. 新增持久层字段tag：dataType:"clob"支持达梦Clob类型映射到string